### PR TITLE
Setup/Override rule in stylelint configuration file to avoid TailwindCSS custom at-rules error

### DIFF
--- a/.stylelintrc.cjs
+++ b/.stylelintrc.cjs
@@ -19,5 +19,12 @@ module.exports = {
     "length-zero-no-unit": true,
     "unit-allowed-list": ["em", "rem", "%", "ms", "s", "deg", "vh", "vw", "fr"],
     "max-nesting-depth": 4,
+    "at-rule-no-unknown": null,
+    "scss/at-rule-no-unknown": [
+      true,
+      {
+        ignoreAtRules: ["tailwind", "layer", "apply", "variants", "responsive"],
+      },
+    ],
   },
 };

--- a/src/assets/scss/vendors/_tailwindcss.scss
+++ b/src/assets/scss/vendors/_tailwindcss.scss
@@ -1,4 +1,3 @@
-/* stylelint-disable scss/at-rule-no-unknown */
 @tailwind base;
 @tailwind components;
 @tailwind utilities;


### PR DESCRIPTION
###  Tasks Done
---
- Override rule in `stylelint` configuration file to avoid TailwindCSS custom at-rules error.